### PR TITLE
Fix to avoid duplicating click events on already existing images on screen.

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -143,6 +143,7 @@ $(document).ready(function() {
     event.preventDefault();
     queryUrl += "&offset=" + currentCountOfGifs;
     console.log(queryUrl);
+    $(".gifImage").off("click");
     makeGiphyApiCall(queryUrl).then(function(giphyResponse) {
       displayGifs(giphyResponse);
     });


### PR DESCRIPTION
Refer [Issue#2](https://github.com/unnikrishnan-r/Giphy-API/issues/2) to have more details on the issue and root cause.

**Solution**
Turn off click events on existing images before adding more GIFs. The displayGifs() will reenable click events on all the images (old and new)

`    $(".gifImage").off("click");
`